### PR TITLE
对文件头损坏的情况做兼容处理

### DIFF
--- a/librarylog4a/src/main/cpp/LogBufferHeader.cpp
+++ b/librarylog4a/src/main/cpp/LogBufferHeader.cpp
@@ -47,9 +47,7 @@ Header* LogBufferHeader::getHeader() {
 
 size_t LogBufferHeader::getHeaderLen() {
     if (isAvailable()) {
-        size_t log_path_len = 0;
-        memcpy(&log_path_len, data_ptr + sizeof(char) + sizeof(size_t), sizeof(size_t));
-        return calculateHeaderLen(log_path_len);
+        return calculateHeaderLen(getLogPathLen());
     }
     return 0;
 }
@@ -83,6 +81,10 @@ size_t LogBufferHeader::getLogLen() {
     if (isAvailable()) {
         size_t log_len = 0;
         memcpy(&log_len, data_ptr + sizeof(char), sizeof(size_t));
+        // log长度总是大于 0 并小于 buffer_size 减去 header 长度的
+        if (log_len < 0 || log_len > (data_size - getHeaderLen())) {
+            log_len = 0;
+        }
         return log_len;
     }
     return 0;
@@ -92,6 +94,10 @@ size_t LogBufferHeader::getLogPathLen() {
     if (isAvailable()) {
         size_t log_path_len = 0;
         memcpy(&log_path_len, data_ptr + sizeof(char) + sizeof(size_t), sizeof(size_t));
+        // logpath 的长度不能大于整个buffer 减去header 中其它数据的长度
+        if (log_path_len < 0 || log_path_len > data_size - calculateHeaderLen(0)) {
+            log_path_len = 0;
+        }
         return log_path_len;
     }
     return 0;

--- a/librarylog4a/src/main/cpp/log4a-lib.cpp
+++ b/librarylog4a/src/main/cpp/log4a-lib.cpp
@@ -64,7 +64,8 @@ static void writeDirtyLogToFile(int buffer_fd) {
     struct stat fileInfo;
     if(fstat(buffer_fd, &fileInfo) >= 0) {
         size_t buffered_size = static_cast<size_t>(fileInfo.st_size);
-        if(buffered_size > 0) {
+        // buffer_size 必须是大于文件头长度的，否则会导致下标溢出
+        if(buffered_size > LogBufferHeader::calculateHeaderLen(0)) {
             char *buffer_ptr_tmp = (char *) mmap(0, buffered_size, PROT_WRITE | PROT_READ, MAP_SHARED, buffer_fd, 0);
             if (buffer_ptr_tmp != MAP_FAILED) {
                 LogBuffer *tmp = new LogBuffer(buffer_ptr_tmp, buffered_size);


### PR DESCRIPTION
# 这是针对一个可能导致崩溃的Bug做的修改

**复现步骤：**
1. 导入库，使用 `armeabi-v7a`, `arm64-v8a` 两种 so 库，由于设备是 64 位的，所以首选使用的 `arm64-v8a` 的库
2. 后期apk 体积增大，缩减so库体积，删除了 `arm64-v8a` 的so库，这时候设备使用了 `armeabi-v7a` 的so库
3. 打开app崩溃

**原因：写脏数据时文件头读取异常**

arm64-v8a 是64位的，所以里面的文件头长度和 32 位是不同的，例如 LogBufferHeader.cpp 里面的这个方法
```
size_t LogBufferHeader::calculateHeaderLen(size_t log_path_len) {
    return sizeof(char) + sizeof(size_t) + sizeof(size_t) + log_path_len + sizeof(char);
}
```
这里面获取的长度在 64位和32位情况下，值不同。

所以其它方法同理， `getLogLen` 和 `getLogPathLen` 增加判断，获取的值如果不符合预期，则返回 0 

**这样处理只是使程序不崩溃，但是其实还是会导致写脏数据失败**

